### PR TITLE
Address issue setting Console.WindowWidth using dotnetcore on a mac

### DIFF
--- a/src/BetterConsoleTables/Table.cs
+++ b/src/BetterConsoleTables/Table.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace BetterConsoleTables
@@ -339,7 +340,10 @@ namespace BetterConsoleTables
             }
             else
             {
-                Console.WindowWidth = row.Length + 1;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+                {
+                    Console.WindowWidth = row.Length + 1;
+                }
                 return row;
             }
         }


### PR DESCRIPTION
I added logic in the PadRow method to check if the runtime is windows before attempting to set the Console.WindowWidth property. Before this change, an exception would be thrown if the console width was less than the row's length. I only tested this on a Mac.

```
Unhandled Exception: System.PlatformNotSupportedException: Operation is not supported on this platform.
   at System.ConsolePal.set_WindowWidth(Int32 value)
   at System.Console.set_WindowWidth(Int32 value)
   at BetterConsoleTables.Table.PadRow(String row)
```