### PR TITLE
TableConfiguration.ConsoleAvailable static property

### DIFF
--- a/src/BetterConsoleTables/BetterConsoleTables.csproj
+++ b/src/BetterConsoleTables/BetterConsoleTables.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>net471;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageVersion>1.0.0</PackageVersion>
     <Authors>Douglas Gaskell</Authors>
     <Description>Better tables for your console application</Description>
@@ -12,15 +12,16 @@
     <LicenceUrl>https://github.com/douglasg14b/BetterConsoleTables/LICENCE</LicenceUrl>
     <PackageTags>console table tables</PackageTags>
   </PropertyGroup>
+
+   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+      <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="System.Reflection.TypeExtensions">
-      <Version>4.3.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
+   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+      <DefineConstants>$(DefineConstants);STANDARD;STANDARD20</DefineConstants>
+   </PropertyGroup>
+   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+      <DefineConstants>$(DefineConstants);STANDARD;STANDARD13</DefineConstants>
+   </PropertyGroup>
 
 </Project>

--- a/src/BetterConsoleTables/Table.cs
+++ b/src/BetterConsoleTables/Table.cs
@@ -334,6 +334,8 @@ namespace BetterConsoleTables
         //Pads the row out to the edge of the console, if row is wider than console expand console window
         private string PadRow(string row)
         {
+            if (!TableConfiguration.ConsoleAvailable) return row;
+
             if(row.Length < Console.WindowWidth)
             {
                 return row.PadRight(Console.WindowWidth - 1);

--- a/src/BetterConsoleTables/TableConfiguration.cs
+++ b/src/BetterConsoleTables/TableConfiguration.cs
@@ -183,7 +183,7 @@ namespace BetterConsoleTables
             headerBottomIntersection = '┼';
             innerIntersection = '┼';
 
-            if (!Console.OutputEncoding.Equals(Encoding.UTF8))
+            if (ConsoleAvailable && !Console.OutputEncoding.Equals(Encoding.UTF8))
             {
                 Console.OutputEncoding = Encoding.UTF8;
             }
@@ -214,7 +214,7 @@ namespace BetterConsoleTables
             headerBottomIntersection = '╬';
             innerIntersection = '╬';
 
-            if (!Console.OutputEncoding.Equals(Encoding.UTF8))
+            if (ConsoleAvailable && !Console.OutputEncoding.Equals(Encoding.UTF8))
             {
                 Console.OutputEncoding = Encoding.UTF8;
             }
@@ -254,5 +254,10 @@ namespace BetterConsoleTables
         {
             return new TableConfiguration(Style.UnicodeAlt);
         }
+        
+        /// <summary>
+        /// Set to false when console is not available to avoid exceptions.
+        /// </summary>
+        public static bool ConsoleAvailable { get; set; } = true;
     }
 }


### PR DESCRIPTION
* Some assembly hygine for targeting frameworks.
* Fixes #5 by adding a global static property to avoid exceptions when executed in enviornments where console is not present (such as LINQPad).

Turns out, detecting if your code has a console attached is a non-trivial process. :rofl: at Microsoft. 

The only reliable way I could find is to actually call the underlying exception throwing `Console.WindowHeight/Width` API and wait for it to throw an exception to test if a console is present or not.

https://stackoverflow.com/questions/6408588/how-to-tell-if-there-is-a-console

https://stackoverflow.com/questions/1188658/how-can-a-c-sharp-windows-console-application-tell-if-it-is-run-interactively

`Environment.UserInteractive` is `true` in **LINQPad** and in a standard **Console Application**. 

Structured error handling (SHE) is the only reliably way to check if the console is attached or not; but using SHE is a performance killer.

So, I mostly opted for a global flag. The reason it's global was mostly because `TableConfiguration.Unicode()` is static and set defaults where `Console.OutputEncoding` is getting set too; which throws again and so the flag can't be an instance flag during `TableConfiguration` construction.

I guess it's okay since it's kind of an obscure scenario with how I'm using this; but it does work pretty well now in LINQPad. :+1: 